### PR TITLE
Add url to package.json.  npm install (via cordova plugin add ...) fails due to invalid package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
 	"name": "com.ozexpert.devicemeta",
 	"version": "0.0.2",
+	"url": "https://github.com/schmookeeg/cordova-plugin-device-meta",
 	"description": "Cordova Device Meta Plugin",
 	"cordova": {
 		"id": "com.ozexpert.devicemeta",


### PR DESCRIPTION
Hi, Chris Scott from Transistor Software.  I'm working on EngageMode for Jesse Hercules.

This simply fixes an invalid `package.json`, allowing `cordova plugin add` to work.