### PR TITLE
Fixed up plugin spec for cordova plugin add

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
 	"name": "com.ozexpert.devicemeta",
 	"version": "0.0.2",
+	"url": "https://github.com/schmookeeg/cordova-plugin-device-meta",
 	"description": "Cordova Device Meta Plugin",
 	"cordova": {
 		"id": "com.ozexpert.devicemeta",

--- a/package.json
+++ b/package.json
@@ -1,10 +1,10 @@
 {
-	"name": "com.ozexpert.devicemeta",
+	"name": "cordova-plugin-device-meta",
 	"version": "0.0.2",
 	"url": "https://github.com/schmookeeg/cordova-plugin-device-meta",
 	"description": "Cordova Device Meta Plugin",
 	"cordova": {
-		"id": "com.ozexpert.devicemeta",
+		"id": "cordova-plugin-devicemeta",
 		"platforms": [
 			"android",
 			"ios"

--- a/plugin.xml
+++ b/plugin.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='utf-8'?>
-<plugin id="com.ozexpert.devicemeta" version="0.0.2" xmlns="http://apache.org/cordova/ns/plugins/1.0" xmlns:android="http://schemas.android.com/apk/res/android">
+<plugin id="cordova-plugin-device-meta" version="0.0.2" xmlns="http://apache.org/cordova/ns/plugins/1.0" xmlns:android="http://schemas.android.com/apk/res/android">
 	<name>DeviceMeta</name>
 	<description>Some Device Meta Information for Cordova Apps</description>
 	<license>Apache 2.0</license>


### PR DESCRIPTION
- Added missing entries to `package.json`
- Re-name plugin to npm-friendly `cordova-plugin-device-meta` rather than `.`-based `com.ozexpert.devicemeta`.

Fixes error on `cordova plugin add`
```
Discovered plugin "com.ozexpert.devicemeta" in config.xml. Adding it to the project
Failed to restore plugin "com.ozexpert.devicemeta" from config.xml. You might need to try adding it again. Error: Failed to fetch plugin git+https://github.com/schmookeeg/cordova-plugin-device-meta.git#6624916ed646bb0b1fe2fdf7a1d74c51aa07013a via registry.
Probably this is either a connection problem, or plugin spec is incorrect.
Check your connection and plugin name/version/URL.
Failed to get absolute path to installed module
```